### PR TITLE
Fix cross-compiling the docs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,3 +63,16 @@ task:
     - cargo update -Zminimal-versions
     - cargo check --all-targets
   before_cache_script: rm -rf $HOME/.cargo/registry/index
+
+# Ensure that the docs can be cross-compiled, as Cirrus does.
+task:
+  name: Cross docs
+  container:
+    image: rustlang/rust:nightly
+  cargo_cache:
+    folder: $HOME/.cargo/registry
+    fingerprint_script: cat Cargo.lock || echo ""
+  doc_script:
+    - rustup target add x86_64-unknown-freebsd
+    - cargo doc --target x86_64-unknown-freebsd --no-deps -p freebsd-libgeom-sys -p freebsd-libgeom
+  before_cache_script: rm -rf $HOME/.cargo/registry/index

--- a/freebsd-libgeom-sys/build.rs
+++ b/freebsd-libgeom-sys/build.rs
@@ -1,9 +1,10 @@
 // vim: tw=80
 
-use std::env;
-use std::path::PathBuf;
-
+#[cfg(target_os = "freebsd")]
 fn main() {
+    use std::env;
+    use std::path::PathBuf;
+
     println!("cargo:rustc-link-lib=geom");
     let bindings = bindgen::Builder::default()
         .header("/usr/include/libgeom.h")
@@ -21,3 +22,11 @@ fn main() {
         .expect("Couldn't write bindings!");
 }
 
+#[cfg(not(target_os = "freebsd"))]
+fn main() {
+    // If we're building not on FreeBSD, there's no way the build can succeed.
+    // This probably means we're building docs on docs.rs, so set this config
+    // variable.  We'll use it to stub out the crate well enough that
+    // freebsd-libgeom's docs can build.
+    println!("cargo:rustc-cfg=crossdocs");
+}

--- a/freebsd-libgeom-sys/src/fakes.rs
+++ b/freebsd-libgeom-sys/src/fakes.rs
@@ -1,0 +1,9 @@
+//! Fake definitions good enough to cross-build freebsd-libgeom's docs
+//!
+//! docs.rs does all of its builds on Linux, so the usual build script fails.
+//! As a workaround, we skip the usual build script when doing cross-builds, and
+//! define these stubs instead.
+pub struct devstat();
+pub struct gident();
+pub struct gmesh();
+pub struct timespec(i32);

--- a/freebsd-libgeom-sys/src/lib.rs
+++ b/freebsd-libgeom-sys/src/lib.rs
@@ -4,6 +4,8 @@
 //! These are raw, `unsafe` FFI bindings.  Here be dragons!  You probably
 //! shouldn't use this crate directly.  Instead, you should use the
 //! [`freebsd-libgeom`](https://crates.io/crates/freebsd-libgeom) crate.
+#![cfg_attr(crossdocs, doc="")]
+#![cfg_attr(crossdocs, doc="These docs are just stubs!  Don't trust them.")]
 
 // bindgen generates some unconventional type names
 #![allow(non_camel_case_types)]
@@ -14,4 +16,10 @@
 // https://github.com/rust-lang/rust-bindgen/issues/1651
 #![cfg_attr(test, allow(deref_nullptr))]
 
+#[cfg(not(crossdocs))]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+#[cfg(crossdocs)]
+mod fakes;
+#[cfg(crossdocs)]
+pub use fakes::*;


### PR DESCRIPTION
docs.rs builds docs for all targets from a Linux host, so nothing that
uses a build.rs script that expects to run elsewhere will work.

Detect when we're cross-compiling and build stubs in place of
freebsd-libgeom-sys.  The stubs are good enough for freebsd-libgeom's
docs to build, but no better.

Also, test cross-compiling the docs in CI.