### PR TITLE
Fix detecting GEOM consumers

### DIFF
--- a/freebsd-libgeom/examples/iostat.rs
+++ b/freebsd-libgeom/examples/iostat.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 if let Some(1) = gident.rank() {
                     let stats = Statistics::compute(curstat, prevstat, etime);
                     println!("{:8} {:>7.0} {:>7.0} {:>8.1} {:>8.1} {:>5.0} {:>5.0} {:>5.0} {:>5.0} {:>4} {:>3.0}",
-                        gident.name().to_string_lossy(),
+                        gident.name().unwrap().to_string_lossy(),
                         stats.transfers_per_second_read(),
                         stats.transfers_per_second_write(),
                         stats.mb_per_second_read() * 1024.0,

--- a/gstat/src/main.rs
+++ b/gstat/src/main.rs
@@ -513,8 +513,8 @@ impl DataSource {
             if let Some(gident) = self.tree.lookup(curstat.id()) {
                 if let Some(rank) = gident.rank() {
                     let stats = Statistics::compute(curstat, prevstat, etime);
-                    let elem = Element::new(&gident.name().to_string_lossy(),
-                        rank, &stats);
+                    let name = gident.name().unwrap().to_string_lossy();
+                    let elem = Element::new(&name, rank, &stats);
                     self.items.push(elem);
                 }
             }


### PR DESCRIPTION
Previously we just looked at the lg_geom field and assumed that non-null
meant the GIdent was a provider.  But that field is actually
uninitialized for providers.  This led to displaying some consumers,
with blank names.  Fix by checking for providerness in the
Gident::{name, rank} methods.