### PR TITLE
Don't truncate the Name column when all devices are filtered out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ name = "freebsd-libgeom-sys"
 version = "0.1.2"
 dependencies = [
  "bindgen",
+ "regex",
 ]
 
 [[package]]

--- a/gstat/src/main.rs
+++ b/gstat/src/main.rs
@@ -575,6 +575,7 @@ impl StatefulTable {
             .block(Block::default())
             .highlight_style(selected_style)
             .widths(widths)
+            .column_spacing(0)
     }
 }
 
@@ -656,7 +657,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .filter(|col| col.enabled)
                 .map(|col| {
                     if col.name == "Name" {
-                        max_name_width
+                        max_name_width.max(col.min_width())
                     } else {
                         col.min_width()
                     }
@@ -665,6 +666,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .unwrap_or_else(|| NonZeroU16::new(1).unwrap());
             let rects = Layout::default()
                 .direction(Direction::Horizontal)
+                .margin(0)
                 .constraints(
                     (0..ntables.into())
                     .map(|_| Constraint::Percentage(100 / u16::from(ntables)))


### PR DESCRIPTION
* Compute a minimum width for the Name column, even if there are no rows
* Set tui's column spacing to 0. We build spacing into the width specification and text formatting.
* Set the Layout's margin to 0, just in case the default changes.