### PR TITLE
Fix the build with Rust 1.72.0+

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -57,11 +57,8 @@ task:
     - cargo audit
   # Test our minimal version spec
   minver_test_script:
-    # We can't check minver for gstat itself, since confy fails to build with
-    # its minium specified versions.  So just check freebsd-libgeom.
     - . $HOME/.cargo/env
-    - cd freebsd-libgeom
-    - cargo update -Zminimal-versions
+    - cargo update -Zdirect-minimal-versions
     - cargo check --all-targets
   before_cache_script: rm -rf $HOME/.cargo/registry/index
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,6 @@ name = "freebsd-libgeom-sys"
 version = "0.1.3"
 dependencies = [
  "bindgen",
- "regex",
 ]
 
 [[package]]
@@ -436,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -483,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -494,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
 	"gstat",
 	"freebsd-libgeom",

--- a/freebsd-libgeom-sys/Cargo.toml
+++ b/freebsd-libgeom-sys/Cargo.toml
@@ -21,6 +21,3 @@ pre-release-replacements = []
 
 [build-dependencies]
 bindgen = { version = "0.64.0", features=[] }
-# We don't use regex directly, but we must depend on 1.5.1 so that bindgen
-# builds with -Zminimal-versions.
-regex = "1.5.1"

--- a/freebsd-libgeom/CHANGELOG.md
+++ b/freebsd-libgeom/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Fix the build with Rust 1.72.0+
+  (#[21](https://github.com/asomers/gstat-rs/pull/21))
+
 ## [ 0.2.2 ] - 2023-05-29
 
 ### Fixed

--- a/gstat/CHANGELOG.md
+++ b/gstat/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Fix the build with Rust 1.72.0+
+  (#[21](https://github.com/asomers/gstat-rs/pull/21))
+
 ## [ 0.1.3 ] - 2023-05-29
 
 ### Fixed

--- a/gstat/Cargo.toml
+++ b/gstat/Cargo.toml
@@ -29,13 +29,14 @@ confy = "0.5.0"
 freebsd-libgeom = { version = "0.2.2", path = "../freebsd-libgeom" }
 humanize-rs = "0.1.5"
 nix = { version = "0.26.1", default-features = false, features = ["poll", "time"] }
-serde = "1.0"
-serde_derive = "1.0"
+serde = "1.0.97"
+serde_derive = "1.0.97"
 termion = "1.5"
 tui = { version = "0.15.0", features = ["termion"] }
 
 [dependencies.regex]
-version = "1"
+# Directly, gstat only needs regex 1.3.  But transitively bindgen needs 1.5.1 or later.
+version = "1.6"
 # Disable the unicode feature, since geom providers names are always ASCII
 features = [ "perf", "std" ]
 


### PR DESCRIPTION
Also, fix the minver CI task by using the new -Zdirect-minimal-versions flag.  This requires changing deps a little bit, because the flag doesn't work perfectly.  In particular, it doesn't know that different crates within the workspace can have different dependency versions.