### PR TITLE
Minor maintenance stuff.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,9 +260,9 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "humanize-rs"

--- a/freebsd-libgeom/src/lib.rs
+++ b/freebsd-libgeom/src/lib.rs
@@ -5,6 +5,9 @@
 //! missing.  Open a Github issue if you have a good use for them.
 //! <https://www.freebsd.org/cgi/man.cgi?query=libgeom>
 
+// https://github.com/rust-lang/rust-clippy/issues/1553
+#![allow(clippy::redundant_closure_call)]
+
 use freebsd_libgeom_sys::*;
 use lazy_static::lazy_static;
 use std::{


### PR DESCRIPTION
* Update the hermit-abi dependency.  We don't even build it, but this makes "cargo audit" shut up.

* Suppress an unhelpful Clippy lint.