### PR TITLE
Correctly resetting the terminal when quitting the application

### DIFF
--- a/gstat/CHANGELOG.md
+++ b/gstat/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Correctly reset terminal settings when quitting the application.
+  (#[30](https://github.com/asomers/gstat-rs/pull/30))
+
 ## [0.1.5] - 2023-12-19
 
 ### Fixed

--- a/gstat/src/main.rs
+++ b/gstat/src/main.rs
@@ -883,6 +883,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         eprintln!("Warning: failed to save config file: {e}");
     }
     terminal.set_cursor(0, terminal.size()?.height - 1)?;
+    crossterm::terminal::disable_raw_mode().unwrap();
 
     Ok(())
 }


### PR DESCRIPTION
When quitting the application, reset the terminal settings.  This is necessary for bash and ksh93, but not for sh, csh, tcsh, and fish.

Fixes #28