### PR TITLE
Tweak the colors for better contrast

### DIFF
--- a/gstat/CHANGELOG.md
+++ b/gstat/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Better color contrast, especially on OSX Terminal
+  (#[32](https://github.com/asomers/gstat-rs/pull/32))
+
 - Correctly reset terminal settings when quitting the application.
   (#[30](https://github.com/asomers/gstat-rs/pull/30))
 

--- a/gstat/src/main.rs
+++ b/gstat/src/main.rs
@@ -611,7 +611,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut table = StatefulTable::default();
     data.sort(sort_idx, cfg.reverse);
 
-    let normal_style = Style::default().bg(Color::LightBlue);
+    let normal_style = Style::default().bg(Color::Blue);
 
     terminal.clear()?;
     loop {
@@ -620,7 +620,9 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .enumerate()
                 .filter(|(_i, col)| col.enabled)
                 .map(|(i, col)| {
-                    let style = Style::default().fg(Color::Red);
+                    let style = Style::default()
+                        .fg(Color::LightYellow)
+                        .add_modifier(Modifier::BOLD);
                     let style = if sort_idx == Some(i) {
                         style.add_modifier(Modifier::REVERSED)
                     } else {

--- a/gstat/src/main.rs
+++ b/gstat/src/main.rs
@@ -611,7 +611,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut table = StatefulTable::default();
     data.sort(sort_idx, cfg.reverse);
 
-    let normal_style = Style::default().bg(Color::Blue);
+    let normal_style = Style::default().bg(Color::LightBlue);
 
     terminal.clear()?;
     loop {


### PR DESCRIPTION
"Blue" and "Red" are both too dark on OSX Terminal.  The new setting looks better on other terminals, too.

Fixes #29