### PR TITLE
Update mio to 0.8.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,9 +466,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",

--- a/freebsd-libgeom-sys/src/fakes.rs
+++ b/freebsd-libgeom-sys/src/fakes.rs
@@ -6,4 +6,6 @@
 pub struct devstat();
 pub struct gident();
 pub struct gmesh();
+#[allow(dead_code)]
+#[derive(Copy, Clone)]
 pub struct timespec(i32);


### PR DESCRIPTION
This makes cargo-audit shut up.  It isn't really necessary, though, because the mio vulnerability only affects Windows.

RUSTSEC-2024-0019