### PR TITLE
Use Rust edition 2021

### DIFF
--- a/freebsd-libgeom-sys/Cargo.toml
+++ b/freebsd-libgeom-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "freebsd-libgeom-sys"
 version = "0.1.5"
-edition = "2018"
+edition = "2021"
 authors = ["Alan Somers <asomers@gmail.com>"]
 license = "BSD-2-Clause"
 repository = "https://github.com/asomers/gstat-rs"

--- a/freebsd-libgeom/Cargo.toml
+++ b/freebsd-libgeom/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/asomers/gstat-rs"
 description = "Rust bindings to FreeBSD's libgeom library"
 categories = ["api-bindings", "os::freebsd-apis"]
 keywords = ["freebsd"]
-rust-version = "1.64"
+rust-version = "1.70"
 
 [package.metadata.docs.rs]
 targets = [

--- a/freebsd-libgeom/Cargo.toml
+++ b/freebsd-libgeom/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "freebsd-libgeom"
 version = "0.2.4"
-edition = "2018"
+edition = "2021"
 authors = ["Alan Somers <asomers@gmail.com>"]
 license = "BSD-2-Clause"
 repository = "https://github.com/asomers/gstat-rs"

--- a/gstat/Cargo.toml
+++ b/gstat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gstat"
 version = "0.1.6"
-edition = "2018"
+edition = "2021"
 authors = ["Alan Somers <asomers@gmail.com>"]
 license = "BSD-2-Clause"
 repository = "https://github.com/asomers/gstat-rs"

--- a/gstat/Cargo.toml
+++ b/gstat/Cargo.toml
@@ -9,7 +9,7 @@ description = "Enhanced replacement for FreeBSD's gstat utility"
 categories = ["command-line-utilities"]
 keywords = ["freebsd"]
 include = ["src/**/*", "LICENSE", "README.md"]
-rust-version = "1.64"
+rust-version = "1.70"
 
 [package.metadata.docs.rs]
 targets = [


### PR DESCRIPTION
Since the oldest compatible compiler supports it.

Also, update the rust-version Cargo tag to what we test in CI.