### PR TITLE
Change the geom-exporter's binary's name

### DIFF
--- a/freebsd-geom-exporter/Cargo.toml
+++ b/freebsd-geom-exporter/Cargo.toml
@@ -15,6 +15,10 @@ pre-release-replacements = [
     { file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}" }
 ]
 
+[[bin]]
+name = "geom-exporter"
+path = "src/main.rs"
+
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 freebsd-libgeom = { version = "0.2.4", path = "../freebsd-libgeom" }


### PR DESCRIPTION
Keep "freebsd-" in the crate name, but remove it from the binary name.