### PR TITLE
Add RUST_LOG support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +432,7 @@ name = "freebsd-geom-exporter"
 version = "0.1.1"
 dependencies = [
  "clap",
+ "env_logger",
  "freebsd-libgeom",
  "prometheus_exporter",
  "regex",
@@ -559,6 +583,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "kasuari"
@@ -756,6 +804,21 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]

--- a/freebsd-geom-exporter/CHANGELOG.md
+++ b/freebsd-geom-exporter/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Added
+
+- Added `RUST_LOG` support.
+  (#[51](https://github.com/asomers/gstat-rs/pull/51))
+
 ## [0.1.1] - 2024-04-18
 
 ### Fixed

--- a/freebsd-geom-exporter/Cargo.toml
+++ b/freebsd-geom-exporter/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
+env_logger = "0.11"
 freebsd-libgeom = { version = "0.3.0", path = "../freebsd-libgeom" }
 prometheus_exporter = "0.8.4"
 

--- a/freebsd-geom-exporter/src/main.rs
+++ b/freebsd-geom-exporter/src/main.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use clap::Parser;
+use env_logger::{Builder, Env};
 use freebsd_libgeom::{Snapshot, Statistics, Tree};
 use prometheus_exporter::prometheus::register_gauge_vec;
 use regex::Regex;
@@ -31,6 +32,10 @@ struct Cli {
 
 fn main() -> Result<(), Box<dyn Error>> {
     let cli: Cli = Cli::parse();
+
+    // Setup logger with default level info so we can see the messages from
+    // prometheus_exporter.
+    Builder::from_env(Env::default().default_filter_or("info")).init();
 
     // Parse address used to bind exporter to.
     let ia: IpAddr = cli.addr.parse().unwrap();


### PR DESCRIPTION
By using env_logger.  This enables prometheus_exporter's internal log messages to be logged.