### PR TITLE
Convert the exporter to use axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,16 +83,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii"
-version = "1.1.0"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "bindgen"
@@ -127,6 +173,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
 name = "castaway"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,12 +201,6 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
-
-[[package]]
-name = "chunked_transfer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clang-sys"
@@ -235,7 +281,7 @@ checksum = "f29222b549d4e3ded127989d523da9e928918d0d0d7f7c1690b439d0d538bae9"
 dependencies = [
  "directories",
  "serde",
- "thiserror 2.0.12",
+ "thiserror",
  "toml",
 ]
 
@@ -431,11 +477,14 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 name = "freebsd-geom-exporter"
 version = "0.1.1"
 dependencies = [
+ "anyhow",
+ "axum",
  "clap",
  "env_logger",
  "freebsd-libgeom",
- "prometheus_exporter",
+ "prometheus",
  "regex",
+ "tokio",
 ]
 
 [[package]]
@@ -452,6 +501,39 @@ name = "freebsd-libgeom-sys"
 version = "0.1.6"
 dependencies = [
  "bindgen",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
 ]
 
 [[package]]
@@ -508,6 +590,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +640,43 @@ name = "humanize-rs"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "016b02deb8b0c415d8d56a6f0ab265e50c22df61194e37f9be75ed3a722de8a6"
+
+[[package]]
+name = "hyper"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "ident_case"
@@ -615,7 +774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def1b67294a9fdc95eeeeafd1209c7a1b8a82aa0bf80ac2ab2a7d0318e9c7622"
 dependencies = [
  "hashbrown",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -697,10 +856,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -807,6 +978,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,29 +1037,16 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
  "memchr",
  "parking_lot",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "prometheus_exporter"
-version = "0.8.5"
-source = "git+https://github.com/AlexanderThaller/prometheus_exporter?rev=c49efe6#c49efe614486f998b20eb410ae0caf3e904cf540"
-dependencies = [
- "ascii",
- "either",
- "log",
- "prometheus",
- "thiserror 1.0.69",
- "tiny_http",
+ "thiserror",
 ]
 
 [[package]]
@@ -908,7 +1084,7 @@ dependencies = [
  "kasuari",
  "lru",
  "strum",
- "thiserror 2.0.12",
+ "thiserror",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -961,7 +1137,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -1032,18 +1208,27 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1102,6 +1287,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,13 +1342,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.69"
+name = "sync_wrapper"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "thiserror"
@@ -1161,18 +1353,7 @@ version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.12",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1208,15 +1389,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
-name = "tiny_http"
-version = "0.12.0"
+name = "tokio"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "ascii",
- "chunked_transfer",
- "httpdate",
- "log",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1259,6 +1453,33 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "unicode-ident"
@@ -1324,6 +1545,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1566,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,3 @@ members = [
 ]
 
 [patch.crates-io]
-prometheus_exporter = { git = "https://github.com/AlexanderThaller/prometheus_exporter", rev = "c49efe6" }

--- a/freebsd-geom-exporter/Cargo.toml
+++ b/freebsd-geom-exporter/Cargo.toml
@@ -20,10 +20,13 @@ name = "geom-exporter"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1.0.14"
+axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
 clap = { version = "4.0", features = ["derive"] }
 env_logger = "0.11"
 freebsd-libgeom = { version = "0.3.0", path = "../freebsd-libgeom" }
-prometheus_exporter = "0.8.4"
+prometheus = {version = "0.14.0", default-features = false, features = [] }
+tokio = { version = "^1.25", features = ["macros", "net", "rt"] }
 
 [dependencies.regex]
 # Directly, gstat only needs regex 1.3.  But transitively bindgen needs 1.5.1 or later.

--- a/freebsd-geom-exporter/src/main.rs
+++ b/freebsd-geom-exporter/src/main.rs
@@ -1,15 +1,26 @@
 // vim: tw=80
 use std::{
-    error::Error,
     net::{IpAddr, SocketAddr},
     process::exit,
+    sync::{Arc, LazyLock},
 };
 
-use clap::Parser;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use clap::{
+    error::{Error as ClapError, ErrorKind as ClapErrorKind},
+    Parser,
+};
 use env_logger::{Builder, Env};
 use freebsd_libgeom::{Snapshot, Statistics, Tree};
-use prometheus_exporter::prometheus::register_gauge_vec;
+use prometheus::{register_gauge_vec, GaugeVec, TextEncoder};
 use regex::Regex;
+use tokio::net::TcpListener;
 
 /// Export GEOM device metrics to Prometheus
 #[derive(Debug, Default, clap::Parser)]
@@ -21,17 +32,160 @@ struct Cli {
     #[clap(short = 'P', long = "physical")]
     physical: bool,
     /// Only report devices with names matching this regex.
-    #[clap(short = 'f', long = "include")]
-    include:  Option<String>,
+    #[clap(short = 'f', long = "include", value_parser = regex_parser)]
+    include:  Option<Regex>,
     /// Do not report devices with names matching this regex
-    #[clap(short = 'F', long = "exclude")]
-    exclude:  Option<String>,
+    #[clap(short = 'F', long = "exclude", value_parser = regex_parser)]
+    exclude:  Option<Regex>,
     /// TCP port
     #[clap(short = 'p', default_value = "9248")]
     port:     u16,
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn regex_parser(s: &str) -> Result<Regex, ClapError> {
+    match Regex::new(s) {
+        Ok(s) => Ok(s),
+        Err(e) => Err(ClapError::raw(ClapErrorKind::ValueValidation, e)),
+    }
+}
+
+static BUSY_TIME: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
+        "geom_busy_time",
+        "Cumulative time in seconds that the device had at least one \
+         outstanding operation",
+        &["device"],
+    )
+    .expect("cannot create gauge")
+});
+static BYTES: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
+        "geom_bytes",
+        "Total bytes processed",
+        &["device", "method"]
+    )
+    .expect("cannot create gauge")
+});
+static DURATION: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
+        "geom_duration",
+        "Total time spent processing commands in seconds",
+        &["device", "method"]
+    )
+    .expect("cannot create gauge")
+});
+static OPS: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
+        "geom_operations",
+        "Total operations processed",
+        &["device", "method"]
+    )
+    .expect("cannot create gauge")
+});
+static QUEUE_LENGTH: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
+        "geom_queue_length",
+        "Number of incomplete transactions at the sampling instant",
+        &["device"]
+    )
+    .expect("cannot create gauge")
+});
+
+/// Wrapper type that implements IntoResponse for anyhow::Error.
+#[derive(Debug)]
+struct AppError(anyhow::Error);
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, format!("{}", self.0))
+            .into_response()
+    }
+}
+
+async fn metrics(cli: State<Arc<Cli>>) -> Result<String, AppError> {
+    // inner relies on an implicit Into conversion to return anyhow::Error
+    let inner = || -> Result<String, anyhow::Error> {
+        // Note: it might be more efficient to only call Tree:new if we detect
+        // that a device has arrived or departed.  But on a system with hundreds
+        // of disks, it only takes 13ms.
+        let mut tree = Tree::new()?;
+        let mut current = Snapshot::new()?;
+        BUSY_TIME.reset();
+
+        for item in current.iter() {
+            if let Some(gident) = tree.lookup(item.id()) {
+                if let Some(rank) = gident.rank() {
+                    if rank > 1 && cli.physical {
+                        continue;
+                    }
+                    let device = gident.name().unwrap().to_string_lossy();
+                    if !cli
+                        .include
+                        .as_ref()
+                        .map(|f| f.is_match(&device))
+                        .unwrap_or(true)
+                    {
+                        continue;
+                    }
+                    if cli
+                        .exclude
+                        .as_ref()
+                        .map(|f| f.is_match(&device))
+                        .unwrap_or(false)
+                    {
+                        continue;
+                    }
+                    let stats = Statistics::compute(item, None, 0.0);
+
+                    BUSY_TIME
+                        .with_label_values(&[&device])
+                        .set(stats.busy_time());
+                    QUEUE_LENGTH
+                        .with_label_values(&[&device])
+                        .set(stats.queue_length() as f64);
+                    BYTES
+                        .with_label_values(&[&*device, "read"])
+                        .set(stats.total_bytes_read() as f64);
+                    DURATION
+                        .with_label_values(&[&*device, "read"])
+                        .set(stats.total_duration_read());
+                    OPS.with_label_values(&[&*device, "read"])
+                        .set(stats.total_transfers_read() as f64);
+                    BYTES
+                        .with_label_values(&[&*device, "write"])
+                        .set(stats.total_bytes_write() as f64);
+                    DURATION
+                        .with_label_values(&[&*device, "write"])
+                        .set(stats.total_duration_write());
+                    OPS.with_label_values(&[&*device, "write"])
+                        .set(stats.total_transfers_write() as f64);
+                    BYTES
+                        .with_label_values(&[&*device, "free"])
+                        .set(stats.total_bytes_free() as f64);
+                    DURATION
+                        .with_label_values(&[&*device, "free"])
+                        .set(stats.total_duration_free());
+                    OPS.with_label_values(&[&*device, "free"])
+                        .set(stats.total_transfers_free() as f64);
+                    DURATION
+                        .with_label_values(&[&*device, "other"])
+                        .set(stats.total_duration_other());
+                    OPS.with_label_values(&[&*device, "other"])
+                        .set(stats.total_transfers_other() as f64);
+                }
+            }
+        }
+        let metric_families = prometheus::gather();
+        let encoder = TextEncoder::new();
+        let body = encoder.encode_to_string(&metric_families)?;
+        Ok(body)
+    };
+    // Now convert the error type again.
+    inner().map_err(AppError)
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
     let cli: Cli = Cli::parse();
 
     // Setup logger with default level info so we can see the messages from
@@ -45,128 +199,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     });
     let sa = SocketAddr::new(ia, cli.port);
 
-    let include = cli.include.as_ref().map(|s| {
-        Regex::new(s).unwrap_or_else(|e| {
-            eprintln!("Cannot parse include regex: {e}");
-            exit(2);
-        })
-    });
-    let exclude = cli.exclude.as_ref().map(|s| {
-        Regex::new(s).unwrap_or_else(|e| {
-            eprintln!("Cannot parse exclude regex: {e}");
-            exit(2);
-        })
-    });
+    let app = Router::new()
+        .route("/metrics", get(metrics))
+        // Annoyingly, with_state requires its argument to be `Send` even if
+        // we're using a single-threaded runtime.  So we must use Arc instead of
+        // Rc.
+        .with_state(Arc::new(cli));
 
-    let exporter = prometheus_exporter::start(sa).unwrap_or_else(|e| {
-        eprintln!("Error starting exporter: {e}");
-        exit(1);
-    });
-
-    let duration = register_gauge_vec!(
-        "geom_duration",
-        "Total time spent processing commands in seconds",
-        &["device", "method"]
-    )
-    .expect("cannot create gauge");
-    let bytes = register_gauge_vec!(
-        "geom_bytes",
-        "Total bytes processed",
-        &["device", "method"]
-    )
-    .expect("cannot create gauge");
-    let ops = register_gauge_vec!(
-        "geom_operations",
-        "Total operations processed",
-        &["device", "method"]
-    )
-    .expect("cannot create gauge");
-    let busy_time = register_gauge_vec!(
-        "geom_busy_time",
-        "Cumulative time in seconds that the device had at least one \
-         outstanding operation",
-        &["device"]
-    )
-    .expect("cannot create gauge");
-    let queue_length = register_gauge_vec!(
-        "geom_queue_length",
-        "Number of incomplete transactions at the sampling instant",
-        &["device"]
-    )
-    .expect("cannot create gauge");
-
-    loop {
-        let _guard = exporter.wait_request();
-        // Note: it might be more efficient to only call Tree:new if we detect
-        // that a device has arrived or departed.  But on a system with hundreds
-        // of disks, it only takes 13ms.
-        let mut tree = Tree::new()?;
-        let mut current = Snapshot::new()?;
-        busy_time.reset();
-        duration.reset();
-        bytes.reset();
-        ops.reset();
-        queue_length.reset();
-        for item in current.iter() {
-            if let Some(gident) = tree.lookup(item.id()) {
-                if let Some(rank) = gident.rank() {
-                    if rank > 1 && cli.physical {
-                        continue;
-                    }
-                    let device = gident.name().unwrap().to_string_lossy();
-                    if !include
-                        .as_ref()
-                        .map(|f| f.is_match(&device))
-                        .unwrap_or(true)
-                    {
-                        continue;
-                    }
-                    if exclude
-                        .as_ref()
-                        .map(|f| f.is_match(&device))
-                        .unwrap_or(false)
-                    {
-                        continue;
-                    }
-                    let stats = Statistics::compute(item, None, 0.0);
-
-                    busy_time
-                        .with_label_values(&[&device])
-                        .set(stats.busy_time());
-                    queue_length
-                        .with_label_values(&[&device])
-                        .set(stats.queue_length() as f64);
-                    bytes
-                        .with_label_values(&[&device, "read"])
-                        .set(stats.total_bytes_read() as f64);
-                    duration
-                        .with_label_values(&[&device, "read"])
-                        .set(stats.total_duration_read());
-                    ops.with_label_values(&[&device, "read"])
-                        .set(stats.total_transfers_read() as f64);
-                    bytes
-                        .with_label_values(&[&device, "write"])
-                        .set(stats.total_bytes_write() as f64);
-                    duration
-                        .with_label_values(&[&device, "write"])
-                        .set(stats.total_duration_write());
-                    ops.with_label_values(&[&device, "write"])
-                        .set(stats.total_transfers_write() as f64);
-                    bytes
-                        .with_label_values(&[&device, "free"])
-                        .set(stats.total_bytes_free() as f64);
-                    duration
-                        .with_label_values(&[&device, "free"])
-                        .set(stats.total_duration_free());
-                    ops.with_label_values(&[&device, "free"])
-                        .set(stats.total_transfers_free() as f64);
-                    duration
-                        .with_label_values(&[&device, "other"])
-                        .set(stats.total_duration_other());
-                    ops.with_label_values(&[&device, "other"])
-                        .set(stats.total_transfers_other() as f64);
-                }
-            }
-        }
-    }
+    let listener = TcpListener::bind(sa).await.unwrap();
+    axum::serve(listener, app).await.unwrap()
 }


### PR DESCRIPTION
This replaces prometheus-exporter/tiny-http with prometheus/axum. The former pair are unmaintained and have bugs with no released solutions.

Also bring in the anyerror crate, which helps to bridge freebsd-libgeom's error types to those that axum needs.

Fixes #54