### PR TITLE
Fix running on FreeBSD/riscv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,9 +786,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.173"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libloading"

--- a/freebsd-geom-exporter/CHANGELOG.md
+++ b/freebsd-geom-exporter/CHANGELOG.md
@@ -12,6 +12,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix running on stock FreeBSD/riscv.
+  (#[57](https://github.com/asomers/gstat-rs/pull/57))
+
 - Handle `ECONNABORTED` errors without exiting.  This completely removes
   dependencies on the unmaintained `prometheus-exporter` and `tiny-http`
   crates.

--- a/gstat/CHANGELOG.md
+++ b/gstat/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix running on stock FreeBSD/riscv.
+  (#[57](https://github.com/asomers/gstat-rs/pull/57))
+
 - Better error messages
   (#[41](https://github.com/asomers/gstat-rs/pull/41))
 


### PR DESCRIPTION
By updating to libc 0.2.176 or newer.  This change is untested on riscv, but it is necessary to run on a stock riscv kernel, which does not have COMPAT_11X enabled.