### PR TITLE
Fix recent CI failures

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,6 +62,15 @@ task:
   minver_test_script:
     - . $HOME/.cargo/env
     - cargo update -Zdirect-minimal-versions
+    # Workaround a ratatui bug.
+    # Cargo update -Zdirect-minimal-versions downgrades serde, which is a
+    # direct dependency.  But time-0.3.27 and later require serde-0.1.184 or
+    # later.  So time must be downgraded too.  But ratatui-widgets
+    # miss-specifies its time dependency as 0.3, even though it really needs
+    # 0.3.37.  So the build fails.  Fix it by upgrading time after downgrading
+    # everything else.
+    # https://github.com/ratatui/ratatui/pull/2306
+    - cargo update -p time
     - cargo check --all-targets
   fmt_script:
     - . $HOME/.cargo/env


### PR DESCRIPTION
A bug in ratatui mis-specified its dependency on the time crate.  Even though time is not a direct dependency of gstat-rs, cargo update -Zdirect-minimal-versions was forced to downgrade it in order to maintain compatibility with the lower version of serde.  That caused the build to fail.  Fix by explicitly upgrading time.  This bug will be fixed in the next release of ratatui-widgets.

https://github.com/ratatui/ratatui/pull/2306