### PR TITLE
Update transitive dependencies to resolve upstream security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
 ]
@@ -829,9 +829,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown",
 ]
@@ -901,9 +901,9 @@ checksum = "44a1290799eababa63ea60af0cbc3f03363e328e58f32fb0294798ed3e85f444"
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -1334,24 +1334,24 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "libc",
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tokio"

--- a/freebsd-geom-exporter/CHANGELOG.md
+++ b/freebsd-geom-exporter/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Updated the `bytes` dependency to resolve security advisories in
+  that crate.
+  (#[66](https://github.com/asomers/gstat-rs/pull/66))
+
 ## [0.1.2] - 2025-10-27
 
 ### Added

--- a/freebsd-libgeom/src/lib.rs
+++ b/freebsd-libgeom/src/lib.rs
@@ -600,7 +600,10 @@ impl Sub for Timespec {
 pub struct Tree(Pin<Box<gmesh>>);
 
 impl Tree {
-    // FreeBSD BUG: geom_lookupid takes a mutable pointer when it could be const
+    // FreeBSD BUG: prior to 14.4, 15.1, and 16.0, geom_lookupid took a mutable
+    // pointer when it could've been const.
+    // https://github.com/freebsd/freebsd-src/commit/cff33cd16d6751ab0693a00473ccfe7c8132cfdf
+    #[allow(clippy::unnecessary_mut_passed)]
     pub fn lookup<'a>(&'a mut self, id: Id) -> Option<Gident<'a>> {
         let raw = unsafe { geom_lookupid(&mut *self.0, id.id) };
         NonNull::new(raw).map(|ident| Gident {

--- a/gstat/CHANGELOG.md
+++ b/gstat/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - ReleaseDate
+
+### Fixed
+
+- Updated the `time` and `lru` dependencies to resolve security advisories in
+  those crates.
+  (#[66](https://github.com/asomers/gstat-rs/pull/66))
+
 ## [0.1.7] - 2025-12-11
 
 ### Fixed


### PR DESCRIPTION
Update transitive dependencies to resolve upstream security advisories
    
* Update the bytes transitive dependency to v1.11.1
  RUSTSEC-2026-0007
    
* Update the time transitive dependency to 0.3.41
  RUSTSEC-2026-0009
    
* Update the lru transitive dependency to 0.16.2
  RUSTSEC-2026-0002